### PR TITLE
Invert GPIOs values on Chuwi Hi12 tablet

### DIFF
--- a/goodix.h
+++ b/goodix.h
@@ -86,6 +86,7 @@ struct goodix_ts_data {
 	struct regulator *vddio;
 	struct gpio_desc *gpiod_int;
 	struct gpio_desc *gpiod_rst;
+	bool inverted_gpios;
 	int gpio_count;
 	int gpio_int_idx;
 	enum gpiod_flags gpiod_rst_flags;


### PR DESCRIPTION
Chuwi Hi12 tablet has ActiveLow INT and inverted RST.
[@kernins](https://github.com/kernins/linux-chwhi12) did some adaptations for 4.x Linux kernel (long time ago).
This PR applies the inverted gpios logic to goodix code from Linux 5.17.